### PR TITLE
Fix Neo4j password option check

### DIFF
--- a/passinspector/passinspector.py
+++ b/passinspector/passinspector.py
@@ -92,7 +92,7 @@ def main(dcsync_filename="", passwords_filename="", file_prefix="", prepare_hash
     if neo4j_username:
         global NEO4J_USERNAME
         NEO4J_USERNAME = neo4j_username
-    if neo4j_username:
+    if neo4j_password:
         global NEO4J_PASSWORD
         NEO4J_PASSWORD = neo4j_password
 


### PR DESCRIPTION
## Summary
- fix condition to load Neo4j password argument

## Testing
- `python -m py_compile passinspector/*.py`