### PR TITLE
Fix help text bug and add leetspeak test

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,14 +72,14 @@ PassInspector generates three output files:
 ## Usage
 
 ```bash
-python PassInspector.py -d <dcsync-file> -p <password-file> [-a <admin-users-file> -c <custom-search-terms> -e <enabled-users-file> -sp <spray-passwords-file> -su <spray-users-file> -lh <local-hashes-file> -cs <credential-stuffing-file> -csd <cred-stuffing-domains> -db -nd -dpi -fp <file-prefix>]
+python3 passinspector/passinspector.py -d <dcsync-file> -p <password-file> [-a <admin-users-file> -c <custom-search-terms> -e <enabled-users-file> -sp <spray-passwords-file> -su <spray-users-file> -lh <local-hashes-file> -cs <credential-stuffing-file> -csd <cred-stuffing-domains> -db -nd -dpi -fp <file-prefix>]
 ```
 
 **Example**
 Just running the script will return the shortest, longest, and most used password. Also, common passwords such as "password" and "qwerty" will be checked. The file should be a list of passwords. If there are hashes and/or usernames in the list, they should be separated from the passwords by a colon `:` and the password should be the last item on the line.
 ```bash
 ┌──(twilson㉿kali)-[~/]
-└─$ python PassInspector.py -d dcsync.txt -p cracked.txt
+└─$ python3 passinspector/passinspector.py -d dcsync.txt -p cracked.txt
 
 ==============================
 PassInspector  -  Version 2.3
@@ -116,7 +116,7 @@ Done!
 If you want to search for terms related to the organization or similar, add terms with the `-c` option as comma separated words, no spaces.
 ```bash
 ┌──(twilson㉿kali)-[~/]
-└─$ python PassInspector.py -d dcsync.txt -p cracked.txt -c citrix -np neo4j
+└─$ python3 passinspector/passinspector.py -d dcsync.txt -p cracked.txt -c citrix -np neo4j
 
 ==============================
 PassInspector  -  Version 2.3

--- a/passinspector/passinspector.py
+++ b/passinspector/passinspector.py
@@ -167,7 +167,7 @@ def main(dcsync_filename="", passwords_filename="", file_prefix="", prepare_hash
     text_blank_passwords, result_blank_enabled = blank_enabled_search(user_database, text_blank_passwords)
     pbar.update(1)
     # Step 7: Check for credential stuffing matches
-    text_cred_stuffing, result_cred_stuffing = cred_stuffing_check(cred_stuffing_accounts, dcsync_results)
+    text_cred_stuffing, result_cred_stuffing = cred_stuffing_check(cred_stuffing_accounts, user_database)
     pbar.update(1)
     # Step 8: Check for spray matches
     user_database, num_spray_matches, num_pass_spray_matches = check_if_spray(user_database, spray_users_filename,

--- a/passinspector/utils.py
+++ b/passinspector/utils.py
@@ -71,7 +71,6 @@ def gather_arguments():
     parser.add_argument('-a', '--admins', help='(OPTIONAL) A file containing a list of domain '
                                                'administrative users. The script will check if the passwords for these '
                                                'users are used on other accounts by using hashes. The format should be '
-                                               'DOMAIN\\USERNAME or USERNAME. BloodHound JSON files are also accepted.'
                                                'DOMAIN\\USERNAME or USERNAME. BloodHound JSON files are also accepted. '
                                                'Overrides automatic Neo4j queries.')
 

--- a/tests/test_leetspeak.py
+++ b/tests/test_leetspeak.py
@@ -1,0 +1,24 @@
+import os
+import sys
+import types
+
+# Ensure the project root is on the import path
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+# Stub external dependencies required during import
+sys.modules['tqdm'] = types.ModuleType('tqdm')
+sys.modules['tqdm'].tqdm = lambda *args, **kwargs: args[0]
+
+sys.modules['neo4j'] = types.ModuleType('neo4j')
+sys.modules['neo4j'].GraphDatabase = object
+
+sys.modules['xlsxwriter'] = types.ModuleType('xlsxwriter')
+
+from passinspector.passinspector import convert_to_leetspeak
+
+
+def test_convert_to_leetspeak_password_variants():
+    variants = convert_to_leetspeak("password")
+    assert "p@ssword" in variants
+    assert "passw0rd" in variants
+    assert "pa55word" in variants


### PR DESCRIPTION
## Summary
- fix `--admins` help text duplication
- use the real user list for credential stuffing checks
- update README examples to use the proper script path
- add pytest for `convert_to_leetspeak`

## Testing
- `pytest -q`