### PR TITLE
Handle None usernames in JSON imports

### DIFF
--- a/passinspector/pass_inspector_args.py
+++ b/passinspector/pass_inspector_args.py
@@ -106,6 +106,7 @@ class PassInspectorArgs:
     def get_filenames(self):
         if not self.file_prefix:
             self.file_prefix = datetime.now().strftime("%Y%m%d_%H%M%S")
+            
             return
 
         if not self.dcsync_filename:

--- a/passinspector/passinspector.py
+++ b/passinspector/passinspector.py
@@ -6,8 +6,16 @@ import os
 import re
 import sys
 from tqdm import tqdm
-from passinspector import utils
-from passinspector import export_xlsx
+
+# Support running as a script or as part of the package
+if __package__ is None or __package__ == "":
+    # When executed directly, add the parent directory so absolute imports work
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    from passinspector import utils  # type: ignore
+    from passinspector import export_xlsx  # type: ignore
+else:
+    from . import utils  # type: ignore
+    from . import export_xlsx  # type: ignore
 
 class User:
     def __init__(self, domain, username, lmhash, nthash, password, cracked, has_lm,

--- a/passinspector/passinspector.py
+++ b/passinspector/passinspector.py
@@ -1451,11 +1451,23 @@ def prepare_hashes(pi_data):
 def parse_students(user_database, students_filename):
     print("Parsing students")
     students = utils.file_to_userlist(students_filename)
+
+    names = set()
+    domain_names = set()
+    for entry in students:
+        uname = entry.get('USERNAME')
+        domain = entry.get('DOMAIN')
+        if not uname:
+            continue
+        uname_l = uname.lower()
+        names.add(uname_l)
+        if domain:
+            domain_names.add((domain.lower(), uname_l))
+
     for user in user_database:
-        for student in students:
-            if user.username.lower() == student['USERNAME'].lower():
-                user.student = True
-                break
+        user_key = (user.domain.lower(), user.username.lower())
+        if user_key in domain_names or user.username.lower() in names:
+            user.student = True
     return user_database
 
 

--- a/passinspector/utils.py
+++ b/passinspector/utils.py
@@ -311,6 +311,6 @@ def read_json_file(file_path):
             parts = raw.split('/', 1)
             formatted_usernames.append({"USERNAME": parts[1], "DOMAIN": parts[0]})
         else:
-            formatted_usernames.append({"USERNAME": raw})
+            formatted_usernames.append({"USERNAME": raw, "DOMAIN": None})
 
     return formatted_usernames

--- a/passinspector/utils.py
+++ b/passinspector/utils.py
@@ -260,7 +260,12 @@ def read_json_file(file_path):
         print(f"Error: File '{file_path}' not found.")
         return None
     except json.JSONDecodeError as e:
-        print(f"Error: Failed to decode JSON in file '{file_path}': {e}")
+        # Many callers try JSON first and fall back to text. Avoid noisy
+        # errors when a non-JSON file (e.g., a spray list) is provided.
+        if file_path.lower().endswith('.json'):
+            print(f"Error: Failed to decode JSON in file '{file_path}': {e}")
+        elif DEBUG_MODE:
+            print(f"[DEBUG] Failed JSON parse for '{file_path}': {e}")
         return None
 
     # decide which structure we're dealing with

--- a/passinspector/utils.py
+++ b/passinspector/utils.py
@@ -274,19 +274,43 @@ def read_json_file(file_path):
 
     formatted_usernames = []
     for entry in records:
-        # pick the right field
-        if isinstance(entry, dict) and 'label' in entry:
-            raw = entry['label']
-        elif isinstance(entry, dict) and 'u.samaccountname' in entry:
-            raw = entry['u.samaccountname']
-        else:
+        raw = None
+
+        # Known structures
+        if isinstance(entry, dict):
+            if 'label' in entry:
+                raw = entry['label']
+            elif 'u.samaccountname' in entry:
+                raw = entry['u.samaccountname']
+            else:
+                # Try to dynamically locate a string field that looks like a username
+                for key, value in entry.items():
+                    if isinstance(value, str) and any(t in key.lower() for t in ['samaccount', 'username', 'name']):
+                        raw = value
+                        break
+        elif isinstance(entry, str):
+            raw = entry
+
+        # Skip entries where we failed to extract a usable string
+        if not raw or not isinstance(raw, str):
             print(f"Warning: skipping unrecognized entry: {entry}")
             continue
 
-        parts = raw.split('@', 1)
-        if len(parts) == 2:
+        raw = raw.strip()
+        if not raw:
+            continue
+
+        # Split out domain if present
+        if '@' in raw:
+            parts = raw.split('@', 1)
             formatted_usernames.append({"USERNAME": parts[0], "DOMAIN": parts[1]})
+        elif '\\' in raw:
+            parts = raw.split('\\', 1)
+            formatted_usernames.append({"USERNAME": parts[1], "DOMAIN": parts[0]})
+        elif '/' in raw:
+            parts = raw.split('/', 1)
+            formatted_usernames.append({"USERNAME": parts[1], "DOMAIN": parts[0]})
         else:
-            formatted_usernames.append({"USERNAME": parts[0]})
+            formatted_usernames.append({"USERNAME": raw})
 
     return formatted_usernames

--- a/tests/data/emails-unverified.txt
+++ b/tests/data/emails-unverified.txt
@@ -1,0 +1,3 @@
+20benjamin.wise@example.com
+20blake.dieckeson@example.com
+aaron.daniel@example.com

--- a/tests/data/students.json
+++ b/tests/data/students.json
@@ -1,0 +1,7 @@
+[
+  {"u.samaccountname": "user1"},
+  {"u.samaccountname": null},
+  {"u.samaccountname": "astudentaccount"},
+  {"label": "TEST\\jsmith"},
+  "standalone"
+]

--- a/tests/data/students.json
+++ b/tests/data/students.json
@@ -1,5 +1,5 @@
 [
-  {"u.samaccountname": "user1"},
+  {"u.samaccountname": "user01"},
   {"u.samaccountname": null},
   {"u.samaccountname": "astudentaccount"},
   {"label": "TEST\\jsmith"},

--- a/tests/test_passinspector.py
+++ b/tests/test_passinspector.py
@@ -40,6 +40,11 @@ class PassInspectorTests(unittest.TestCase):
             result = run([flag, value])
             self.assertEqual(result.returncode, 0, msg=f"{flag}: {result.stdout}")
 
+    def test_json_students_file(self):
+        result = run(["-s", "tests/data/students.json"])
+        self.assertEqual(result.returncode, 0, msg=result.stdout)
+        self.assertIn("Student accounts cracked: 1/1", result.stdout)
+
     def test_all_option_output(self):
         args = [
             "-a", "tests/data/admins.txt",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,7 @@
+import io
 import unittest
 from pathlib import Path
+from contextlib import redirect_stdout
 from passinspector import utils
 
 DATA_DIR = Path(__file__).resolve().parent / "data"
@@ -16,6 +18,18 @@ class UtilsJsonTests(unittest.TestCase):
         self.assertIn("astudentaccount", usernames)
         self.assertIn("jsmith", usernames)
         self.assertIn("standalone", usernames)
+
+    def test_file_to_userlist_text_emails(self):
+        txt_file = DATA_DIR / "emails-unverified.txt"
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            users = utils.file_to_userlist(str(txt_file))
+
+        self.assertEqual(buf.getvalue(), "")
+        self.assertEqual(len(users), 3)
+        first = users[0]
+        self.assertEqual(first["USERNAME"], "20benjamin.wise")
+        self.assertEqual(first["DOMAIN"], "example.com")
 
 
 if __name__ == "__main__":

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,7 +12,7 @@ class UtilsJsonTests(unittest.TestCase):
         # The file contains one null entry which should be skipped
         self.assertEqual(len(users), 4)
         usernames = {u["USERNAME"] for u in users}
-        self.assertIn("user1", usernames)
+        self.assertIn("user01", usernames)
         self.assertIn("astudentaccount", usernames)
         self.assertIn("jsmith", usernames)
         self.assertIn("standalone", usernames)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,22 @@
+import unittest
+from pathlib import Path
+from passinspector import utils
+
+DATA_DIR = Path(__file__).resolve().parent / "data"
+
+
+class UtilsJsonTests(unittest.TestCase):
+    def test_file_to_userlist_json_variants(self):
+        json_file = DATA_DIR / "students.json"
+        users = utils.file_to_userlist(str(json_file))
+        # The file contains one null entry which should be skipped
+        self.assertEqual(len(users), 4)
+        usernames = {u["USERNAME"] for u in users}
+        self.assertIn("user1", usernames)
+        self.assertIn("astudentaccount", usernames)
+        self.assertIn("jsmith", usernames)
+        self.assertIn("standalone", usernames)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- improve JSON user parser to skip empty entries and detect usernames from various fields
- allow top-level script to import modules when run directly
- add regression test for parsing JSON user lists with null records

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689a65edb9548320b6e7226bab8d2813